### PR TITLE
New openapi specification location

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -14,3 +14,12 @@ body {
     margin: 0;
     background: #fafafa;
 }
+
+a,
+a:link,
+a:visited,
+a:hover,
+a:active {
+    color: inherit;
+    text-decoration: underline;
+}

--- a/dist/swagger-initializer.js
+++ b/dist/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    urls: [{ url: "https://raw.githubusercontent.com/greenbone/openvas-scanner/main/rust/doc/openapi.yml", name: "Scanner API" },{ url: "https://raw.githubusercontent.com/greenbone/openvas-scanner/main/rust/doc/reverse-sensor-openapi.yml", name: "Reverse Scanner API" }],"urls.primaryName": "Scanner API",
+    urls: [{ url: "https://raw.githubusercontent.com/greenbone/openvas-scanner/main/rust/api/openapi.yml", name: "Scanner API" },{ url: "https://raw.githubusercontent.com/greenbone/openvas-scanner/main/rust/api/reverse-sensor-openapi.yml", name: "Reverse Scanner API" }],"urls.primaryName": "Scanner API",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
This PR changes the location of the API specification files. Note, that https://github.com/greenbone/openvas-scanner/pull/2208 must be merged first. This also adjust how hyperlinks are rendered within the Swagger UI

Jira: SC-1596